### PR TITLE
Update to use consolidated Thompson Sampling API

### DIFF
--- a/src/Plugin/views/sort/AISorting.php
+++ b/src/Plugin/views/sort/AISorting.php
@@ -104,7 +104,7 @@ class AISorting extends SortPluginBase {
         $time_window_seconds = $this->options['time_window_seconds'];
       }
 
-      $scores = $this->experimentManager->getThompsonScoresWithWindow(
+      $scores = $this->experimentManager->getThompsonScores(
         $experiment_uuid,
         $time_window_seconds
       );


### PR DESCRIPTION
## Summary
Updates AI Sorting plugin to use the consolidated Thompson Sampling API from the RL module after the `getThompsonScoresWithWindow()` method removal.

## Changes Made
- ✅ Updated `AISorting::query()` to call `getThompsonScores()` instead of `getThompsonScoresWithWindow()`
- ✅ Passes optional `$time_window_seconds` parameter to maintain same functionality
- ✅ Maintains backward compatibility and existing behavior
- ✅ Cleaner API integration with RL module

## Code Changes
```php
// Before
$scores = $this->experimentManager->getThompsonScoresWithWindow(
  $experiment_uuid,
  $time_window_seconds
);

// After
$scores = $this->experimentManager->getThompsonScores(
  $experiment_uuid,
  $time_window_seconds
);
```

## Dependencies
This change depends on dxpr/rl#6 being merged first, which consolidates the Thompson Sampling API.

## Test Plan
- [x] Verify AI Sorting plugin still works with time windows
- [x] Confirm non-time-windowed sorting still functions
- [x] Check that all existing functionality is preserved
- [x] Validate coding standards compliance

## Files Changed
- `src/Plugin/views/sort/AISorting.php` - Updated API call

Closes #8

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>