### PR TITLE
feat(ux): add RL experiment highlight class for visual branding

### DIFF
--- a/ai_sorting.module
+++ b/ai_sorting.module
@@ -118,6 +118,9 @@ function ai_sorting_views_pre_render(ViewExecutable $view) {
       'rlEndpointUrl' => "{$base_path}/{$rl_path}/rl.php",
       'displayId' => $view->current_display,
     ];
+
+    // Add RL experiment highlight class for visual branding.
+    $view->element['#attributes']['class'][] = 'rl-experiment';
   }
 }
 


### PR DESCRIPTION
## Summary

Add the `rl-experiment` CSS class to Views blocks using AI Sorting, enabling the RL module's animated gradient border branding.

## Changes

- Add `rl-experiment` class in `ai_sorting_views_pre_render()`
- Class applied to the view's root element attributes

## Related

- Depends on dxpr/rl#20 (RL module branding feature)

## Test Plan

- [ ] Enable RL module with branding PR merged
- [ ] Log in as user with "view rl reports" permission
- [ ] Navigate to a page with a Views block using AI Sorting
- [ ] Verify animated gradient border appears around the block
- [ ] Log in as user without permission
- [ ] Verify no border appears

Closes #20