### PR TITLE
Expose experiment report URL in drupalSettings

### DIFF
--- a/ai_sorting.module
+++ b/ai_sorting.module
@@ -109,10 +109,16 @@ function ai_sorting_views_pre_render(ViewExecutable $view) {
     $rl_path = \Drupal::service('extension.list.module')->getPath('rl');
     $base_path = \Drupal::request()->getBasePath();
 
+    // Generate experiment report URL.
+    $experiment_url = Url::fromRoute('rl.reports.experiment_detail', [
+      'experiment_id' => $experiment_id,
+    ])->toString();
+
     // Attach JavaScript library and settings.
     $view->element['#attached']['library'][] = 'ai_sorting/ai_sorting_tracking';
     $view->element['#attached']['drupalSettings']['aiSorting']['views'][$view->id() . '.' . $view->current_display] = [
       'experimentId' => $experiment_id,
+      'experimentUrl' => $experiment_url,
       'entityIds' => $entity_ids,
       'entityUrlMap' => $entity_url_map,
       'rlEndpointUrl' => "{$base_path}/{$rl_path}/rl.php",


### PR DESCRIPTION
Add experimentUrl to drupalSettings for DXPR Builder integration

## Linked issues

- Fix #22

## Summary

- Add `experimentUrl` to the `drupalSettings.aiSorting.views` output
- URL is generated using Drupal's routing system via `Url::fromRoute()`
- Consuming modules can now link to experiment reports without hardcoding URL structure

## Test plan

- [ ] Enable ai_sorting on a View
- [ ] Check `drupalSettings.aiSorting.views` in browser console
- [ ] Verify `experimentUrl` is present and points to correct report page

## Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] My commit messages follow the contributing standards and style of this project.
- [x] My code follows the coding standards and style of this project.
- [x] My code contains no changes that are outside the scope of the issue.
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).