### PR TITLE
SEO: Add branded headers and cross-links to README and project description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# AI Sorting - Self-Learning A/B Testing for Content
+> Part of [DXPR CMS](https://dxpr.com/c/marketing-cms) | The AI-Powered Drupal CMS
+>
+> [Documentation](https://dxpr.com/docs) | [Try Free](https://dxpr.com/try) | [dxpr.com](https://dxpr.com)
+
+# AI Sorting: Self-Learning A/B Testing and Content Optimization for Drupal
 
 Advanced A/B testing for Drupal Views that learns automatically. Instead of
 manually setting up A/B tests, AI Sorting continuously tests all content
@@ -72,3 +76,9 @@ Unlike traditional A/B testing tools, AI Sorting provides:
 
 - [RL module](https://www.drupal.org/project/rl) - Core Thompson Sampling
   algorithm and API for developers
+
+## Related DXPR Modules
+
+- [RL (Reinforcement Learning)](https://www.drupal.org/project/rl) - Thompson Sampling algorithm and API for developers
+- [RL Sorting](https://www.drupal.org/project/rl_sorting) - Views sort plugin powered by reinforcement learning
+- [Analyze](https://www.drupal.org/project/analyze) - Content analysis framework with unified Analyze tab

--- a/docs/ai_sorting_project_desc.html
+++ b/docs/ai_sorting_project_desc.html
@@ -1,3 +1,5 @@
+<p><strong>Part of the <a href="https://dxpr.com/c/marketing-cms">DXPR</a> ecosystem</strong> | the AI-powered no-code platform for Drupal. <a href="https://dxpr.com/try">Try free</a> | <a href="https://dxpr.com/docs">Documentation</a></p>
+
 <p>This module is part of the <a href="https://www.drupal.org/project/rl">RL module</a> ecosystem and included in <a href="https://www.drupal.org/project/dxpr_cms">DXPR CMS</a>.</p>
 
 <blockquote>Advanced A/B testing for content optimization. Automatically tests all your content simultaneously using Thompson Sampling machine learning to surface winners while giving new content fair exposure.</blockquote>
@@ -38,7 +40,7 @@
 
 <div class="note-tip">
   <h4>Prefer a turnkey demo site?</h4>
-  <p>Spin up <strong>DXPR CMS</strong> -- Drupal pre-configured with DXPR Builder, DXPR Theme, AI Sorting module, and security best practices.</p>
+  <p>Spin up <strong>DXPR CMS</strong>, Drupal pre-configured with DXPR Builder, DXPR Theme, AI Sorting module, and security best practices.</p>
   <p><a href="https://www.drupal.org/project/dxpr_cms" title="DXPR CMS platform">Get DXPR CMS »</a></p>
 </div>
 
@@ -57,3 +59,10 @@
     <li>Drupal 10.3+ or 11</li>
   </ul>
 </p>
+
+<h3>Related DXPR Modules</h3>
+<ul>
+<li><a href="https://www.drupal.org/project/rl">RL (Reinforcement Learning)</a> - Thompson Sampling algorithm and API for developers</li>
+<li><a href="https://www.drupal.org/project/rl_sorting">RL Sorting</a> - Views sort plugin powered by reinforcement learning</li>
+<li><a href="https://www.drupal.org/project/analyze">Analyze</a> - Content analysis framework with unified Analyze tab</li>
+</ul>


### PR DESCRIPTION
## Summary
- Add branded DXPR header with links to dxpr.com product pages
- Improve H1 title with descriptive keyword-rich suffix
- Add Related DXPR Modules section for cross-linking
- Strengthens backlink profile to dxpr.com from GitHub/Drupal.org

## SEO Impact
- Backlinks from high-DA GitHub pages to dxpr.com product pages
- Keyword-rich anchor text reinforcing brand-keyword association
- Cross-module linking creating topical authority web